### PR TITLE
fix: fixed Regular Expression compatible @types/react-native v0.64.11+

### DIFF
--- a/add_classname.rb
+++ b/add_classname.rb
@@ -2,5 +2,5 @@ ARGF.each do |line|
   puts line
   # puts "", "    className?: string;" if line =~ /style\?: StyleProp<.*Style>;/
   # Since @types/react-native v0.64.11, `style` is added to `undefined`.
-  puts "", "    className?: string;" if line =~ /style\?: StyleProp<.*Style> | undefined;/
+  puts "", "    className?: string;" if line =~ /style\?: StyleProp<.* \| undefined;/
 end

--- a/add_classname.rb
+++ b/add_classname.rb
@@ -1,4 +1,6 @@
 ARGF.each do |line|
   puts line
-  puts "", "    className?: string;" if line =~ /style\?: StyleProp<.*Style>;/
+  # puts "", "    className?: string;" if line =~ /style\?: StyleProp<.*Style>;/
+  # Since @types/react-native v0.64.11, `style` is added to `undefined`.
+  puts "", "    className?: string;" if line =~ /style\?: StyleProp<.*Style> | undefined;/
 end


### PR DESCRIPTION
I fixed this issue, but the latest version v0.64.12 already exists, requesting a fix for v0.64.11 ~ v0.64.12.

```ruby
ARGF.each do |line|
  puts line
  # puts "", "    className?: string;" if line =~ /style\?: StyleProp<.*Style>;/
  # Since @types/react-native v0.64.11, `style` is added to `undefined`.
  puts "", "    className?: string;" if line =~ /style\?: StyleProp<.* \| undefined;/
end

```

ref:

`https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2d550aee84fb4da77318677f942bf6246c80653e/types/react-native/index.d.ts#L1055`
